### PR TITLE
Correzione bug latenti (passo 2 del piano di rifattorizzazione)

### DIFF
--- a/app/js/HardWiredProperties.js
+++ b/app/js/HardWiredProperties.js
@@ -998,19 +998,19 @@ function evaluateComparison($exp) {
 		if (!isNaN(firstMember.computedVal) && !isNaN(secondMember.computedVal)) {
 			const prototype = prototypeSearch("ci", "bool")
 			let result
-			if (ENODEClass = "eq") {
+			if (ENODEClass === "eq") {
 				result = firstMember.computedVal == secondMember.computedVal;
 			}
-			else if (ENODEClass = "gt") {
+			else if (ENODEClass === "gt") {
 				result = firstMember.computedVal > secondMember.computedVal;
 			}
-			else if (ENODEClass = "geq") {
+			else if (ENODEClass === "geq") {
 				result = firstMember.computedVal >= secondMember.computedVal;
 			}
-			else if (ENODEClass = "lt") {
+			else if (ENODEClass === "lt") {
 				result = firstMember.computedVal < secondMember.computedVal;
 			}
-			else if (ENODEClass = "leq") {
+			else if (ENODEClass === "leq") {
 				result = firstMember.computedVal <= secondMember.computedVal;
 			}
 			let stringResult

--- a/app/js/SaveLoad.js
+++ b/app/js/SaveLoad.js
@@ -106,7 +106,7 @@ function inject(MMLstring, $targetRoleOrENODE, containerRequirements, toBeImport
 	}
 	else{
 		ENODEappend($targetRoleOrENODE, $convertedTree);
-		if(containerRequirements='bool'){//la classe :unlock messa via jquery sembra sia aggiornata dopo la chiamata asincrona
+		if(containerRequirements === 'boolean' || containerRequirements === true){//la classe :unlock messa via jquery sembra sia aggiornata dopo la chiamata asincrona
 			$convertedTree.each(function() {
 				wrapWithDefIfNeededreturnTarget($targetRoleOrENODE,$(this))
 			});

--- a/app/js/UserEvToFunctCall.js
+++ b/app/js/UserEvToFunctCall.js
@@ -86,7 +86,7 @@ function searchEventHandler(event){// trova la definizione della proprietà
    const $found = $('#events').find('[data-enode="eventtoaction"]').filter(function(index){
         const $role = this.ENODE_getRoles('.event');
         if($role.length !== 1){
-            console.warn('Role not found' + field);
+            console.warn('Role not found for event: ' + event);
             res = $()
             return res
         }

--- a/app/js/calculateSpan.js
+++ b/app/js/calculateSpan.js
@@ -309,8 +309,7 @@ function $RolesAffectedByStartPropositionROLES($startProposition) {
 		$startRole = $startProposition.parent()
 	}
 	else if (propParentOp == 'implies' && $startProposition.hasClass('firstMember')) {
-		if ((startENODE_op == 'implies') && $role)
-			$startRole = $propositionParent[0].ENODE_getRoles('.secondMember');
+		$startRole = $propositionParent[0].ENODE_getRoles('.secondMember');
 	}
 	if ($startRole) {
 		//propagate all Roles excluding start Node //note: apply to yourself?


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Obiettivo

Eseguire il passo 2 del piano in `project/specs/software-modules.md`: correggere i bug latenti individuati nell'analisi, senza altre modifiche.

## Correzioni

### `inject` (`SaveLoad.js`)
- **Bug**: `if(containerRequirements='bool')` era un assegnamento, sempre vero — il wrapping con `wrapWithDefIfNeededreturnTarget` veniva eseguito su ogni append (palette, events, ecc.).
- **Fix**: `if (containerRequirements === 'boolean' || containerRequirements === true)` — i chiamanti passano `'boolean'` (`injectAllMMLS` per canvas/result) o `true` (legacy `injectAll` per canvas), mai `'bool'`.

### `evaluateComparison` (`HardWiredProperties.js`)
- **Bug**: `if (ENODEClass = "eq")` (e rami `gt`, `geq`, `lt`, `leq`) usavano assegnamento invece di confronto — `ENODEClass` veniva sovrascritto con `"eq"` al primo ramo e tutte le comparazioni venivano valutate come uguaglianza.
- **Fix**: `===` in tutti e 5 i rami. Verificato: `2>1→true`, `3=3→true`, `5<2→false`, `4>=4→true`, `1<=3→true`.

### `searchEventHandler` (`UserEvToFunctCall.js`)
- **Bug**: `console.warn('Role not found' + field)` referenziava la variabile inesistente `field`.
- **Fix**: `console.warn('Role not found for event: ' + event)`.

### `$RolesAffectedByStartPropositionROLES` (`calculateSpan.js`)
- **Bug**: ramo `implies` con condizione interna `(startENODE_op == 'implies') && $role` — entrambe le variabili non definite, quindi il consequente non veniva mai considerato come punto di partenza per `addRedundant` DnD.
- **Fix**: assegnazione diretta di `$startRole` al `.secondMember` quando la proposizione è nel `firstMember` di un'implicazione.

## Test

- ✅ Suite e2e Playwright (5/5)
- ✅ Smoke test `smoke-expression-manager.js` (11/11)
- ✅ Verifica mirata: tutti e 5 gli operatori di `evaluateComparison`, caricamento sezione `result` con wrap `boolean`, nessun errore JS

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-20644937-afed-422b-8bdd-11b7854648a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-20644937-afed-422b-8bdd-11b7854648a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

