### PR TITLE
Passo 3: eliminazione globali implicite e rename canvasRole

### DIFF
--- a/app/js/AldoUtilities.js
+++ b/app/js/AldoUtilities.js
@@ -50,8 +50,8 @@ function wrapUnwrapUrlString(string, unwrap) {
 	//cutFirstDir wrapUnwrapUrlString("url(../Aabacus/images/a.png)",'cutFirstDir')
 	if (unwrap == 'cutFirstDir') {
 		let arr = string.replace('../', '').split('/');
-		part = arr[1]
-		for (i = 2; i < arr.length; i++) {
+		let part = arr[1]
+		for (let i = 2; i < arr.length; i++) {
 			part = part + '/' + arr[i]
 		}
 		return part
@@ -130,7 +130,7 @@ function identifierToENODE(string){
 	else{
 		ENODEType = 'cn'
 	}
-	$clone = ENODEclone( prototypeSearch("cn","num") )
+	let $clone = ENODEclone( prototypeSearch("cn","num") )
 	$clone[0].ENODE_setName(string);
 	$clone.attr('data-enode', ENODEType);//uso un generico prototipo num e qui specifico se cn o ci
 	return	$clone

--- a/app/js/DnD.js
+++ b/app/js/DnD.js
@@ -103,7 +103,7 @@ if($ENODETarget.length==0){
 	//is there a valid target?(sometimes the $ENODETarget is undefined sometime it is not but there is no [0] element)
 		if($validTgT.length!=0){
 			let $draggedAndTargets = $ENODETarget.add($validTgT); 
-			$commParent = $(commonParent( $draggedAndTargets.toArray() ));	
+			let $commParent = $(commonParent( $draggedAndTargets.toArray() ));	
 			$commParent.addClass('mu_targetsCommonParent')
 		}
 		//make source sortable

--- a/app/js/ExpressionManager.js
+++ b/app/js/ExpressionManager.js
@@ -512,8 +512,8 @@ function attrAcceptToMinMax(acceptString) {
 }
 
 function ENODEclone($node, Extend, removeID) {//default: Extend and RemoveID
-	$clone = $node.clone(); //clona
-	$toBeCleaned = $clone.add($clone.find("*")); //clean discendence too
+	let $clone = $node.clone(); //clona
+	let $toBeCleaned = $clone.add($clone.find("*")); //clean discendence too
 	if (Extend !== false) {
 		ExtendAndInitializeTree($clone);
 	}
@@ -1041,7 +1041,7 @@ function reorderTimes($startTimes, brRemove) {
 		let numeratorFound = false;
 		let childrenArr = $startTimes[0].ENODE_getChildren().toArray()
 		/**metti i reciproci al per ultimi preceduti da br */
-		for (i = 0; childrenArr[i]; i++) {
+		for (let i = 0; childrenArr[i]; i++) {
 			if ($(childrenArr[i]).is('[data-enode=m_inverse]')) {
 				//aggiungi br se ancora non esiste
 				if (!brExist) {

--- a/app/js/HardWiredProperties.js
+++ b/app/js/HardWiredProperties.js
@@ -297,12 +297,12 @@ function validForColl($mouseDownENODE) {
 	}
 	//***** test su ciascun termine
 	const $terms = $parentParent[0].ENODE_getChildren() // ottieni la lista degli addendi
-	for (i = 0; i < $terms.length; i++) {
+	for (let i = 0; i < $terms.length; i++) {
 		const term = $terms[i]
 		let okForThisTerm = false;
 		if ($(term).attr('data-enode') == op) {// se l'addendo è di tipo times controlla ogni fattore
 			const $factors = term.ENODE_getChildren()
-			for (j = 0; j < $factors.length; j++) {
+			for (let j = 0; j < $factors.length; j++) {
 				const factor = $factors[j]
 				//console.log("controllo factor");
 				//console.log(factor);
@@ -369,12 +369,12 @@ function validForPartColl($mouseDownENODE) {
 	}
 	//***** test su ciascun termine
 	const $siblings = $parent.siblings('[data-enode]')
-	for (i = 0; i < $siblings.length; i++) {
+	for (let i = 0; i < $siblings.length; i++) {
 		const term = $siblings[i]
 		let okForThisTerm = false;
 		if ($(term).attr('data-enode') == opT) {// se l'addendo è di tipo times controlla ogni fattore
 			const $factors = term.ENODE_getChildren()
-			for (j = 0; j < $factors.length; j++) {
+			for (let j = 0; j < $factors.length; j++) {
 				const factor = $factors[j]
 				//console.log("controllo factor");
 				//console.log(factor);
@@ -636,7 +636,7 @@ function compose($toBeComp, firstVal, img) {
 	//if( partial.canBeReplaced){ 
 	if (PActx.matchedTF == true) {
 		///****Create Result********
-		$composed = ValToENODEs(partial);
+		let $composed = ValToENODEs(partial);
 		$composed.addClass('selected');//selezione in uscita
 		PActx.$operand = $toBeComp;
 		PActx.msg = "compose";
@@ -734,7 +734,7 @@ function decompose($toBeDec, direction, img) {//"up" for factorize
 				if (primeFactors.length > 1) {// se numero primo non fare nulla
 					$extOp = wrapIfNeeded($toBeDec, op);//se necessario crea una operazione container
 					primeFactors.forEach(function (e, i) {
-						$clone = identifierToENODE(e);
+						let $clone = identifierToENODE(e);
 						ENODEinsertAfter($clone, $toBeDec);
 						if (i == (primeFactors.length - 1)) {
 							$clone.addClass('selected');// l'ultimo fattore rimane selezionato

--- a/app/js/MAIN.js
+++ b/app/js/MAIN.js
@@ -2,7 +2,7 @@
 let GLBsettings
 let debugMode = false
 //debug,normal
-let canvas = document.getElementById('canvasRole');
+let canvasRole = document.getElementById('canvasRole');
 let exclusiveFocus
 //************ inizializza UNDO  ************
 ssnapshot()
@@ -341,7 +341,7 @@ function ExtendAndInitialize($ENODE) {
 
 
 function cancelSelected() {
-	toBeCancelled = $('.selected').filter(function (index) {
+	let toBeCancelled = $('.selected').filter(function (index) {
 		return !ENODEclosedDef(this);
 	})
 	if (toBeCancelled.length != 0) {
@@ -383,7 +383,7 @@ function PActxVisualize(PActx) {
 		$visualization.insertAfter(PActx.$transform)
 		PActx.$transform.append($visualization);
 	} else {
-		$(canvas).append($visualization)
+		$(canvasRole).append($visualization)
 		$visualization.css('position', 'relative');
 		$visualization.css('top', '0px');
 	}

--- a/app/js/PMTutilities.js
+++ b/app/js/PMTutilities.js
@@ -75,8 +75,8 @@ function allStringAinStringB(stringA,stringB){
 
 
 function removeDuplicatesFromString(string){
-	res=""
-	i=0
+	let res=""
+	let i=0
 	while(string[i]){
 		if( res.indexOf(string[i])==-1 )
 			{res=res+string[i]}
@@ -205,7 +205,7 @@ function ENODEdescForPath($ENODE){
 }
    
 function moveOrClearMarksInTree($startENODE,clear){//copy marks from persistent "data-mark" to volatile mark 
-	$subtree = $startENODE.add( $startENODE.find('[data-enode]') )
+	let $subtree = $startENODE.add( $startENODE.find('[data-enode]') )
 	$subtree.each(function(index) {
 		if(clear){//clearVolatile
 			$(this).removeAttr('mark')
@@ -269,7 +269,7 @@ function ENODESmarkUnmark($ENODE,value,attrName,usePermanentMark){
 	}
 	var str=""
 	str=markArray[0]
-	i=1
+	let i=1
 	while( i< markArray.length ){
 		if(markArray[i]){
 			str= str + "-" + markArray[i]
@@ -512,7 +512,7 @@ function orderMatch(PActx,order,replaceInPatternOnly,strictOrder){
 	var $span //span è l'ambito sul quale effettuare le sostituzioni
 	if(replaceInPatternOnly){$span=PActx.$pattern}
 	else{$span=PActx.$cloneProp};
-	$pattern = PActx.$pattern
+	let $pattern = PActx.$pattern
 	if (debugMode) {//show input beside pattern
 		ENODEappendInABSPosition($span,PActx.$operand,"beside")
 	}

--- a/app/js/TranslateFormat.js
+++ b/app/js/TranslateFormat.js
@@ -5,7 +5,7 @@ function ENODEfactorizeMinus($startNode) {
 		return
 	}
 	//è circondato un meno?
-	$extOp = wrapIfNeeded($startNode, "times");
+	let $extOp = wrapIfNeeded($startNode, "times");
 	//se necessario crea una operazione container
 	//aggiungi un fattore "-1"
 	const prototype = prototypeSearch("ci", "num");

--- a/app/js/Undo.js
+++ b/app/js/Undo.js
@@ -1,4 +1,5 @@
 //snapshot manager
+let FILO;
 
 function ssnapshot() {
 	// Attenzione	prima di invocare qualsiasi metodo, chiamare ssnapshot per creare oggetto
@@ -18,7 +19,7 @@ ssnapshot.take = function(){
 }
 
 ssnapshot.undo = function(){
-		let toBeRestored = null; // Inizializza per restituire null se l'undo fallisce
+		let $toBeRestored = null; // Inizializza per restituire null se l'undo fallisce
 		const currentRootElement = getExpressionRootNode(); // Ottiene HTMLElement
 
 		if (currentRootElement && FILO.length > 0) { // Controlla elemento e stack

--- a/app/js/UserEvToFunctCall.js
+++ b/app/js/UserEvToFunctCall.js
@@ -113,7 +113,7 @@ function searchEventHandler(event){// trova la definizione della proprietà
 function searchForProperty(field,value,returnedField){
 	// trova la definizione della proprietà
 	if( value == undefined){ return undefined}
-	let candidates = Array.from( canvas.querySelectorAll('[data-enode=deftrue]') );
+	let candidates = Array.from( canvasRole.querySelectorAll('[data-enode=deftrue]') );
 	let i=0;
 	while(candidates[i]){
 		let $role = candidates[i].ENODE_getRoles().filter('.' + field)

--- a/app/js/addedHardWiredProperties.js
+++ b/app/js/addedHardWiredProperties.js
@@ -58,9 +58,9 @@ function decomposeTens($toBeDec,undefined,img){
 	//var primeFactors = primeFactorization(number);
 	let terms = separateTensHundreds(toBeDec.val);	
 	if(terms.length >1){
-		$extOp = wrapIfNeeded($toBeDec,'plus');//se necessario crea una operazione container
+		let $extOp = wrapIfNeeded($toBeDec,'plus');//se necessario crea una operazione container
 		terms.forEach(function(e,i){
-			$clone = identifierToENODE(e);
+			let $clone = identifierToENODE(e);
 			ENODEinsertAfter($clone, $toBeDec);
 			if(i == (terms.length -1)){
 				$clone.addClass('selected');// l'ultimo fattore rimane selezionato

--- a/app/js/calculateSpan.js
+++ b/app/js/calculateSpan.js
@@ -21,7 +21,7 @@ function $immediateJurisdictionRolesNEW($role) {
 	}
 	//-sameLevel: implies firstMember to secondMember
 	if ((startENODE_op == 'implies') && $role.hasClass('firstMember')) {
-		$secondMember = $startENODE[0].ENODE_getRoles('.secondMember');
+		let $secondMember = $startENODE[0].ENODE_getRoles('.secondMember');
 		$immediateDiscendence = $immediateDiscendence.add($secondMember);
 	}
 	//-downstream: all boolean roles
@@ -72,7 +72,7 @@ function $immediateJurisdictionRolesForAddRedundant($role) {
 	})
 	//downstream implies firstMember
 	if ((startNode_op == 'implies') && $role.hasClass('firstMember')) {
-		$secondMember = $startENODE[0].ENODE_getRoles('.secondMember');
+		let $secondMember = $startENODE[0].ENODE_getRoles('.secondMember');
 		$stepStoneORtarget = $stepStoneORtarget.add($secondMember);
 	}
 	return $stepStoneORtarget
@@ -292,7 +292,7 @@ function $PropositionsAffectedByStartPropositionROLES($startProposition) {
 	//test: $PropositionsAffectedByStartPropositionROLES($('.selected')).each(function(){ENODEparent($(this)).addClass('selected')});
 	let $roles = $RolesAffectedByStartPropositionROLES($startProposition)
 	//from roles to targets:
-	return $targets = $roles.map(function () {
+	return $roles.map(function () {
 		return $(this).children('[data-enode]').not('[data-enode=and]').toArray()
 	})
 }
@@ -326,7 +326,7 @@ function $calculateTargetsAddRedundantROLES($startProposition) {
 	//from roles to targets:
 	// two types of boolean roles exist:1) those with TRUE as neutral elements 2) OTHERS
 	// OR belongs to the second group!!!
-	return $targets = $roles.map(function () {
+	return $roles.map(function () {
 		let op = ENODEparent($(this)).attr("data-enode");
 		if (op == 'or') {
 			//---OR roles are replaced with contained ENODEs if they are not ANDs.

--- a/app/js/inflatedeflate.js
+++ b/app/js/inflatedeflate.js
@@ -183,7 +183,7 @@ function ReplaceOneENODE(node, from_to, neglectSign) {
 						$(e).children().appendTo($bVarRole)
 					})
 				}
-				noBVarChildren = $children.not('bvar')
+				let noBVarChildren = $children.not('bvar')
 				// globale per renderlo disponibile in each
 				$noBVarRole.each(function(i, e) {
 					var places = getNumOfPlaces($(e))[1]
@@ -229,7 +229,7 @@ function $parserForMixedMMLHTML(toBeParsed){
 	//$('#canvasRole').append($workTree)// debug
 	//replace one <dix> node with <div> 
 	let len = $workTree.find('dix').length
-	for(i=0;i<len;i++){
+	for(let i=0;i<len;i++){
 		let $dix = $workTree.find('dix:first');
 		if($dix.length == 0){break}
 		let $children = $dix.children();

--- a/app/js/preload.js
+++ b/app/js/preload.js
@@ -82,7 +82,7 @@ function injectAll(response,rootUrl){
 function injectAllMMLS(response,rootUrl){
 	//let $MML = $(response)
 	let $MML = $parserForMixedMMLHTML(response)
-	$sections=$MML.filter('section')
+	let $sections=$MML.filter('section')
 	ENODEremove($('#canvasRole').children());
 	//**** palette
 	let $paletteContent = $sections.filter('[data-section=palette]').children();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Obiettivo

Passo 3 del piano di modularizzazione (`software-modules.md`): eliminare le assegnazioni implicite su `window` e rinominare la globale fuorviante `canvas` (che puntava a `#canvasRole`, non a `#canvas`).

## Modifiche

### Rename `canvas` → `canvasRole`
- `MAIN.js`: `let canvasRole = document.getElementById('canvasRole')`
- `UserEvToFunctCall.js`: `searchForProperty` usa `canvasRole.querySelectorAll`
- `#canvas` (jQuery, wrapper equazione) resta invariato

### Globali rese esplicite (13 file)
| File | Variabili |
|------|-----------|
| `MAIN.js` | `toBeCancelled` |
| `Undo.js` | `FILO`, `$toBeRestored` (bug fix: prima era dichiarato `toBeRestored` ma usato `$toBeRestored`) |
| `preload.js` | `$sections` |
| `inflatedeflate.js` | `noBVarChildren`, loop `i` |
| `PMTutilities.js` | `res`/`i` in `removeDuplicatesFromString`, `$subtree`, `$pattern`, `i` in `ENODESmarkUnmark` |
| `TranslateFormat.js` | `$extOp` |
| `calculateSpan.js` | `$secondMember`, rimosso assignment in `return` per `$targets` |
| `HardWiredProperties.js` | `$composed`, `$clone`, loop `i`/`j` |
| `AldoUtilities.js` | `$clone`, `part`, loop `i` |
| `ExpressionManager.js` | `$clone`, `$toBeCleaned`, loop `i` |
| `DnD.js` | `$commParent` |
| `addedHardWiredProperties.js` | `$extOp`, `$clone` |

Nessun cambio di comportamento atteso: le variabili restano nello stesso scope funzionale.

## Test

- `node --check` su tutti i file modificati
- Smoke: 11/11
- E2e Playwright: 5/5
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-20644937-afed-422b-8bdd-11b7854648a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-20644937-afed-422b-8bdd-11b7854648a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

