### PR TITLE
Agente css-specialist e pulizia riferimenti GABBA → Tester L4

### DIFF
--- a/.cursor/agents/css-specialist.md
+++ b/.cursor/agents/css-specialist.md
@@ -63,7 +63,7 @@ In `app/index.html` i CSS applicativi seguono jQuery UI, poi IDE → SVG → sty
 2. **Token `:root`** — preferisci variabili CSS esistenti (`--primary-color`, `--num-color`, `--div-radius`, …) prima di introdurre colori/spacing hard-coded.
 3. **Coerenza ENODE** — mantieni convenzioni visive per tipi (`cn`, operatori, `forAll`, equazioni asimmetriche).
 4. **Touch e accessibilità** — target tap adeguati, contrasto leggibile; Aabacus punta anche a tablet (vedi `implementation-details.md`).
-5. **Test** — dopo modifiche rilevanti al canvas o al DnD, chiedi delega al Tester (Playwright / ricette GABBA) o segnala all'utente di verificare con `?demo=1` e preload Hanoi se appropriato.
+5. **Test** — dopo modifiche rilevanti al canvas o al DnD, chiedi delega al ruolo **Tester** (Playwright, ricette in `project/tests/recipes/`) o segnala all'utente di verificare con `?demo=1` e preload Hanoi se appropriato.
 
 ## Output atteso
 

--- a/project/README.md
+++ b/project/README.md
@@ -7,9 +7,9 @@ Materiale di supporto allo sviluppo (non fa parte del deploy dell'app).
 | `specs/` | Documentazione tecnica e concetti |
 | `specs/diagrams/` | Diagrammi architetturali (SVG editabili) |
 | `dev/` | Script di sviluppo (es. ChromeLauncher) |
-| `Organization/` | Agenti, organigramma, handoff, ricette test browser |
+| `Organization/` | Schede ruolo agenti (`roles/`), organigramma (vedi `AGENTS.md`) |
 | `tests/` | Test automatizzati (e2e, helper) |
-| `tests/recipes/` | Ricette browser per agente GABBA |
+| `tests/recipes/` | Ricette browser per il ruolo **Tester** (L4) |
 | `release/` | Packaging e release (futuro) |
 
 ## Test E2E

--- a/project/specs/tests.md
+++ b/project/specs/tests.md
@@ -18,7 +18,7 @@ I test devono comprendere:
 | Iniettore Playwright | `project/tests/helpers/injectTest.js` | Carica core + esercizio in `page.evaluate` |
 | Test manuali console | `project/tests/testViaConsole/` | Istruzioni + script per DnD via DevTools |
 | Test E2E | `project/tests/e2e/` | Playwright: orchestra test, legge pass/fail |
-| Ricette | `project/tests/recipes/` | Step leggibili per agente GABBA |
+| Ricette | `project/tests/recipes/` | Step leggibili per il ruolo **Tester** (L4, `AGENTS.md`) |
 | Spec | `project/specs/tests.md` | Regole e obiettivi |
 
 Gli helper di test **non** sono file serviti da `app/` — Playwright li inietta dopo il caricamento dell'app. Riutilizzano jQuery e globali dell'app (`GLBsettings`, `Sortable`, …) senza duplicarne la logica ENODE.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Obiettivo

Introduce l'agente **css-specialist** e allinea la documentazione al nuovo organigramma ruoli (addio abbozzo GABBA/Luigi).

## Contenuti

### Agente CSS
- File: `.cursor/agents/css-specialist.md`
- Ruolo Specialist (livello 3), perimetro `app/css/`
- Vincoli su classi ENODE accoppiate al JS, riferimenti a `project/specs/`

### Pulizia organizzazione agenti
- `project/README.md` — `Organization/` e ricette browser → ruolo **Tester (L4)**
- `project/specs/tests.md` — ricette allineate a `AGENTS.md`
- `css-specialist.md` — delega test al ruolo Tester (non più GABBA)

## Merge

Dopo merge su `master`, sul Mac:

```bash
git checkout master
git pull
```

## Note

Non modifica codice applicativo (`app/`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-928f546b-7af3-4eb6-b070-37414be7a0b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-928f546b-7af3-4eb6-b070-37414be7a0b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

