### PR TITLE
chore: rimuove CSS orfano esperimento resize Role (somma a matrice)

### DIFF
--- a/app/css/pseudoEl.css
+++ b/app/css/pseudoEl.css
@@ -41,9 +41,6 @@ In this way infix and tag can exist at the same time
 {
 	margin-left: 11px;/*space for infix symbol*/
 }
-[data-enode=plus][data-vis=resizable]>[class*="role"]>[data-enode]/*:not(.sortable-drag)*/{
-	margin: 4px;
-}
 body.hidePlus [data-enode=plus]>[class*="role"]>[data-enode]::before{
 	color:transparent;	
 }
@@ -51,7 +48,7 @@ body[timesdisposition=brTimes] br + [data-enode]::before{
 	background-color:transparent!important;	
 }
 
-[data-enode=plus]>[class*="role"]>[data-enode]:not(:first-of-type):not([data-vis=resizable])::before,
+[data-enode=plus]>[class*="role"]>[data-enode]:not(:first-of-type)::before,
 [data-enode=leq]>.ol_role>[data-enode]:not(:first-of-type)::before,
 [data-enode=lt]>.ol_role>[data-enode]:not(:first-of-type)::before
 /*,[data-enode=segment]>.ul_role>[data-enode]:not(:first-of-type)::before*/{

--- a/app/css/style.css
+++ b/app/css/style.css
@@ -523,7 +523,6 @@ body:not(.fitch):not([tool="declare"])
 }
 
 .exclusiveFocus,
-[data-vis="resizable"],
 .waiting,
 .mu_targetsCommonParentx,
 .mu_span {
@@ -821,34 +820,6 @@ body.debug .operand:not([data-enode]) {
 .toBeUpdated > .infix {
   display: none;
 }
-
-[data-vis="resizable"] > .ul_role {
-  border-radius: 5px;
-  resize: horizontal;
-  overflow: hidden;
-  border-radius: 0px;
-  height: auto;
-  min-width: 20px;
-}
-[data-vis="resizable"] {
-  position: absolute;
-  border-radius: var(--div-radius) var(--div-radius) 0px var(--div-radius);
-}
-
-[data-vis="resizable"] > .ul_role {
-  border-radius: 5px;
-  width: 80px;
-  padding-left: 4px;
-  display: inline-block; /* do not know why but it works*/
-}
-[data-vis="resizable"] > .ul_role > * {
-  display: inline-flex; /* do not know why but it works*/
-}
-/*
-  [data-vis=resizable]>.ul_role>[data-enode]{
-	  margin:0!important;
-  }
-  */
 
 .name {
   pointer-events: none;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Obiettivo

Ripulire il codice dell'esperimento (2020–2021) per ridimensionare i Role delle somme (`plus`) e disporre gli addendi in layout a matrice tramite `data-vis="resizable"` e CSS `resize: horizontal`.

## Cosa c'era

| Componente | Stato prima della PR |
|------------|----------------------|
| JS (`MAIN.js`: dblclick crea `plus` resizable da `cn`, decomposizione matrice) | Già rimosso nel passo 1 dead-code (`3633ad5`) |
| JS (`AldoUtilities.js`: `updateContainerView` grid, d3 hull) | Già rimosso con `AldoUtilities.js` |
| CSS `[data-vis="resizable"]` in `style.css` | **Orfano — rimosso** |
| CSS eccezioni infix per `plus` resizable in `pseudoEl.css` | **Orfano — rimosso** |

## Modifiche

- `app/css/style.css`: eliminate ~30 righe di regole `resizable`
- `app/css/pseudoEl.css`: rimosse eccezioni margin/infix per resizable

## Non toccato

- `timesDisposition` (vertTimes / brTimes)
- `$toBeComposedWithSiblings` (compose con orientamento row/column)
- `display: grid` su palette proprietà
- `firstColumn`/`secondColumn` in Hanoi

## Test

Smoke test PASS.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-103885ed-ea2e-4f88-8a6d-996ca7f42602"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-103885ed-ea2e-4f88-8a6d-996ca7f42602"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

