### PR TITLE
feat: associativeGenDnD + priorità first-wins sui target HW DnD

### DIFF
--- a/app/Data/FOUNDATION.mml
+++ b/app/Data/FOUNDATION.mml
@@ -13,6 +13,7 @@
 					<and>
 					</and>
 					<ci data-tag="associativeDnD" data-tagimg="./images/properties/associate.svg" data-type="bool">true</ci>
+					<ci data-tag="associativeGenDnD" data-tagimg="./images/properties/associate.svg" data-type="bool">true</ci>
 					<ci data-tag="distributiveDnD" data-tagimg="./images/properties/distributive.svg" data-type="bool">true</ci>
 					<ci data-tag="partDistributDnD" data-tagimg="./images/properties/distributive.svg" data-type="bool">true</ci>
 					<ci data-tag="collectDnD" data-tagimg="./images/properties/collect.svg" data-type="bool">true</ci>

--- a/app/js/DnD.js
+++ b/app/js/DnD.js
@@ -87,9 +87,10 @@ if($ENODETarget.length==0){
 		makeSortableMouseDown($validTgTOpen.toArray(), true);
 	}
 	else {
-		//********  determine validTargets for propeties listed in propertiesDnD[i] ***************
-		// Priority: first enabled HW that claims a target wins; later properties skip those nodes
-		// (findTgt may receive $claimedTargets as 4th arg to avoid re-exploring them).
+		//********  determine validTargets for properties listed in propertiesDnD[i] ***************
+		// First-wins: skip targets already claimed (replaces old last-wins setAttribute overwrite).
+		// findTgt may receive $claimedTargets as 4th arg. List order in HardWiredProperties is
+		// reversed vs the old last-wins list so relative HW priorities stay the same.
 		if (!$ENODETarget.length || !$ENODETarget[0].parentElement) { return }//precondition
 		let i = 0
 		let propInCanvasEnabled = getDnDpropEnabled()

--- a/app/js/DnD.js
+++ b/app/js/DnD.js
@@ -88,13 +88,25 @@ if($ENODETarget.length==0){
 	}
 	else {
 		//********  determine validTargets for propeties listed in propertiesDnD[i] ***************
+		// Priority: first enabled HW that claims a target wins; later properties skip those nodes
+		// (findTgt may receive $claimedTargets as 4th arg to avoid re-exploring them).
 		if (!$ENODETarget.length || !$ENODETarget[0].parentElement) { return }//precondition
 		let i = 0
 		let propInCanvasEnabled = getDnDpropEnabled()
+		let $claimedTargets = $()
 		while (propInCanvasEnabled[i]) {
-			let targets = propInCanvasEnabled[i].findTgt($ENODETarget,(event.ctrlKey || event.metaKey),event.altKey);
-			makeTargetsSortableRolesOrENODEs(targets, propInCanvasEnabled[i].name, propInCanvasEnabled[i].icon)
-			$validTgT = $validTgT.add($(targets))
+			let $found = $(propInCanvasEnabled[i].findTgt(
+				$ENODETarget,
+				(event.ctrlKey || event.metaKey),
+				event.altKey,
+				$claimedTargets
+			))
+			let $targets = $found.not($claimedTargets)
+			if ($targets.length) {
+				makeTargetsSortableRolesOrENODEs($targets.toArray(), propInCanvasEnabled[i].name, propInCanvasEnabled[i].icon)
+				$validTgT = $validTgT.add($targets)
+				$claimedTargets = $claimedTargets.add($targets)
+			}
 			i++
 		}
 	}

--- a/app/js/HardWiredProperties.js
+++ b/app/js/HardWiredProperties.js
@@ -10,20 +10,21 @@ class PropertyDnD {
 }
 
 let propertiesDnD = [
-	// PRIORITY: first enabled property that claims a target wins.
-	// DnD.js skips already-claimed targets for subsequent properties in this list.
-	new PropertyDnD('associativeDnD', immediateAssValid, ENODEassociate, ""),
-	new PropertyDnD('associativeGenDnD', associativeGenValid, ENODEassociate, ""),
-	new PropertyDnD('distributiveDnD', validForDist, ENODEdistribute, ""),
-	new PropertyDnD('partDistributDnD', validForPartDist, ENODEPartDistribute, ""),
-	new PropertyDnD('collectDnD', validForColl, ENODEcollect, ""),
-	new PropertyDnD('partCollectDnD', validForPartColl, ENODEpartCollect, ""),
-	new PropertyDnD('replaceDnD', validReplaced, ENODELinkReplace, ""),
-	new PropertyDnD('modusPonensDnD', validModusPonens, ENODEModusPonens, ""),
-	new PropertyDnD('forThisDnD', forThisValid, forThisPar_focus_nofocus, ""),
-	new PropertyDnD('removeRedundantDnD', validRedundant, removeRedundant, ""),
+	// PRIORITY (first-wins): earlier entry claims a target; DnD.js excludes it for later entries.
+	// List order is the reverse of the old last-wins order, so relative priorities are unchanged.
+	// associativeGenDnD sits above associativeDnD (as when it was inserted after it under last-wins).
+	new PropertyDnD('hanoiMoveDnD', validhanoiMove, hanoiMove, ""),
 	new PropertyDnD('addRedundantDnD', validAddRedundant, addRedundant, ""),
-	new PropertyDnD('hanoiMoveDnD', validhanoiMove, hanoiMove, "")
+	new PropertyDnD('removeRedundantDnD', validRedundant, removeRedundant, ""),
+	new PropertyDnD('forThisDnD', forThisValid, forThisPar_focus_nofocus, ""),
+	new PropertyDnD('modusPonensDnD', validModusPonens, ENODEModusPonens, ""),
+	new PropertyDnD('replaceDnD', validReplaced, ENODELinkReplace, ""),
+	new PropertyDnD('partCollectDnD', validForPartColl, ENODEpartCollect, ""),
+	new PropertyDnD('collectDnD', validForColl, ENODEcollect, ""),
+	new PropertyDnD('partDistributDnD', validForPartDist, ENODEPartDistribute, ""),
+	new PropertyDnD('distributiveDnD', validForDist, ENODEdistribute, ""),
+	new PropertyDnD('associativeGenDnD', associativeGenValid, ENODEassociate, ""),
+	new PropertyDnD('associativeDnD', immediateAssValid, ENODEassociate, "")
 ]
 
 

--- a/app/js/HardWiredProperties.js
+++ b/app/js/HardWiredProperties.js
@@ -10,8 +10,10 @@ class PropertyDnD {
 }
 
 let propertiesDnD = [
-	//PRIORITY: last property overwrites previous targets
+	// PRIORITY: first enabled property that claims a target wins.
+	// DnD.js skips already-claimed targets for subsequent properties in this list.
 	new PropertyDnD('associativeDnD', immediateAssValid, ENODEassociate, ""),
+	new PropertyDnD('associativeGenDnD', associativeGenValid, ENODEassociate, ""),
 	new PropertyDnD('distributiveDnD', validForDist, ENODEdistribute, ""),
 	new PropertyDnD('partDistributDnD', validForPartDist, ENODEPartDistribute, ""),
 	new PropertyDnD('collectDnD', validForColl, ENODEcollect, ""),
@@ -66,20 +68,38 @@ function forThisValid(mouseDownNode) {
 	return $valids
 }
 
-function immediateAssValid($mouseDownENODE) {
+/**
+ * Target roles for associative DnD (same-op cluster).
+ * @param {jQuery} $mouseDownENODE - dragged ENODE
+ * @param {boolean} recursive - false: only immediate parent/child same-op (associativeDnD);
+ *   true: whole same-op cluster via tree explorer (associativeGenDnD)
+ * @param {jQuery} [$alreadyClaimed] - roles already claimed by earlier HW properties; skipped
+ */
+function associativeValid($mouseDownENODE, recursive, $alreadyClaimed) {
 	const $parent = ENODEparent($mouseDownENODE);
 	let op;
 	if ($parent !== undefined) { op = $parent.attr("data-enode") }
 	let $validTargetRoles = $();
 	if (OpIsAssociative(op)) {
-		let $validTgtENODEs = $ImmediateAssociativeENODE($parent)
-		// to get every associative target (not just immediate):
-		//let $validTgtENODEs = $RecursiveTreeExplorerCriterium($parent,$ImmediateAssociativeENODE)
+		let $validTgtENODEs = recursive
+			? $RecursiveTreeExplorerCriterium($parent, $ImmediateAssociativeENODE)
+			: $ImmediateAssociativeENODE($parent)
 		$validTgtENODEs.each(function (i, e) {
 			$validTargetRoles = $validTargetRoles.add(e.ENODE_getRoles());
 		});
+		if ($alreadyClaimed && $alreadyClaimed.length) {
+			$validTargetRoles = $validTargetRoles.not($alreadyClaimed)
+		}
 	}
 	return $validTargetRoles
+}
+
+function immediateAssValid($mouseDownENODE, ctrlOrMeta, altKey, $alreadyClaimed) {
+	return associativeValid($mouseDownENODE, false, $alreadyClaimed)
+}
+
+function associativeGenValid($mouseDownENODE, ctrlOrMeta, altKey, $alreadyClaimed) {
+	return associativeValid($mouseDownENODE, true, $alreadyClaimed)
 }
 
 function ENODEassociate(dragged, target, dropped) {

--- a/app/js/UserEvToFunctCall.js
+++ b/app/js/UserEvToFunctCall.js
@@ -58,7 +58,7 @@ function getDnDpropEnabled(dataTag){
 	if(dataTag){$propInCanvas = $propInCanvas.filter('[data-tag=' + dataTag + ']')}
 	let propInCanvasEnabled = $propInCanvas.toArray()
 	let namelist = propInCanvasEnabled.map(function(e){return e.getAttribute('data-tag')})
-	// same name "associativeDnD" must be in  propertiesDnD
+	// same name (e.g. "associativeDnD", "associativeGenDnD") must be in propertiesDnD
 	//Adding a new DnD internal property:
 	//add an element to the array, add a ci to the canvas with data-tag...
 	let propertiesKnokedOut = propertiesDnD.map(function(e){

--- a/app/js/calculateSpan.js
+++ b/app/js/calculateSpan.js
@@ -84,9 +84,9 @@ function $ImmediateAssociativeENODE($starAssociativeOperation) {
 	let $result = $();
 	//upstream if it's same operation
 	let $parent = ENODEparent($starAssociativeOperation)
-	if ($parent.attr("data-enode") === op) {
+	if ($parent.length && $parent.attr("data-enode") === op) {
 		$result = $result.add($parent);
-	} ENODEparent($starAssociativeOperation).filter('[data-enode=' + op + ']');
+	}
 	//downstream same operation
 	let ENODEchildren = $starAssociativeOperation[0].ENODE_getChildren();
 	ENODEchildren.each(function (i, e) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Cosa

- Nuova HW **`associativeGenDnD`**: stessi apply di `associativeDnD` (`ENODEassociate`), ma `findTgt` esplora l’intero cluster same-op (`$RecursiveTreeExplorerCriterium` + `$ImmediateAssociativeENODE`).
- Nucleo condiviso: `associativeValid($enode, recursive, $alreadyClaimed)`.
- Rimando in `FOUNDATION.mml` accanto ad `associativeDnD`.
- **Priorità first-wins** nel loop DnD: i target già reclamati da una proprietà precedente non vengono riproposti (né riconsiderati) dalle HW successive; passati come 4° argomento a `findTgt` dove supportato.

## Comportamento se entrambe sono nel tree

Con `associativeDnD` prima di `associativeGenDnD` nella lista: l’immediata prende i vicini; la generalizzata prende solo i role più lontani del cluster. Se l’esercizio include solo `associativeGenDnD`, un drop può portare `f` direttamente nel plus esterno.

## Test

`node --check` sui file JS toccati.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-103885ed-ea2e-4f88-8a6d-996ca7f42602"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-103885ed-ea2e-4f88-8a6d-996ca7f42602"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

