### PR TITLE
refactor(properties): modulo refine.js post-applicazione

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -166,6 +166,7 @@
 			<script type="text/javascript" src="js/PatternMatchingTrasform.js"></script>
 			<script type="text/javascript" src="js/HardWiredProperties.js"></script>
 			<script type="text/javascript" src="js/addedHardWiredProperties.js"></script>
+			<script type="text/javascript" src="js/refine.js"></script>
 			<!-- 4. persistence — caricamento e salvataggio -->
 			<script type="text/javascript" src="js/SaveLoad.js"></script>
 			<script type="text/javascript" src="js/preload.js"></script>

--- a/app/js/DnD.js
+++ b/app/js/DnD.js
@@ -337,7 +337,7 @@ function clearSortableTargets() {
 	$('*').removeClass('toBeCollected').removeClass('couldBeCollected');
 	$('*').removeClass('dropTarget');
 	$('*').removeClass('TargetsCommonParent');
-	$('*').removeClass('refine_c'); 
+	$('*').removeClass(REFINE_MARKER_CLASS); 
 	let tgts = document.querySelectorAll('.tgt,.notAtgt');
 	let i = 0;
 	while (tgts[i]) {

--- a/app/js/HardWiredProperties.js
+++ b/app/js/HardWiredProperties.js
@@ -206,7 +206,7 @@ function ENODEPartDistribute($dragged, target, dropped) {
 	});
 	const previous = $clone[0].ENODE_getRoles().children().eq(childrenIndex - 1);
 	ENODEinsertAfter($dragged, previous);
-	$parent.addClass("Refine_c");
+	markNeedsRefine($parent);
 	ENODEremove(dropped);
 	PActx.$transform = $parent;
 	PActx.matchedTF = true
@@ -222,7 +222,7 @@ function ENODEdistribute($dragged, target, dropped) {
 	let opD = opIsDistDop(op);
 	const $prototype = prototypeSearch(op)// for example search for times proto
 	$(target)[0].ENODE_getChildren().each(function (i, e) {
-		e.classList.add("Refine_c");
+		markNeedsRefine(e);
 		const $clone = ENODEclone($prototype)//create times
 		const $cloneDragged = ENODEclone($dragged)// clone dragged
 		ENODEinsertBefore($clone, $(this));
@@ -236,8 +236,8 @@ function ENODEdistribute($dragged, target, dropped) {
 		//$cloneDragged.css({display:""})
 	})
 	const $draggedParent = $dragged[0].ENODEparent();
-	$draggedParent.addClass("Refine_c");//mark external operation as remove if pointless
-	$(target).addClass("Refine_c");//mark target operation as remove if pointless
+	markNeedsRefine($draggedParent);//mark external operation as remove if pointless
+	markNeedsRefine(target);//mark target operation as remove if pointless
 	ENODEremove($dragged);
 	PActx.$transform = $parent;
 	PActx.matchedTF = true
@@ -373,7 +373,7 @@ function ENODEpartCollect($dragged, $target) {
 	let opd = $draggedParent.attr("data-enode")
 
 	let $commonGranParent = ENODEparent($targetParent);
-	$commonGranParent.addClass("Refine_c");
+	markNeedsRefine($commonGranParent);
 
 
 	if (opt == opd && opIsDistDop(opt)) {//both have same distributable op
@@ -441,13 +441,13 @@ function ENODEcollect($dragged, $target) {
 	if ($parent !== undefined) { op = $parent.attr("data-enode") }
 	let extOp
 	extOp = wrapIfNeeded($parentParent, op)
-	ENODEparent($dragged).addClass("Refine_c")
-	ENODEparent($(".CouldBeCollected")).addClass("Refine_c")
+	markNeedsRefine(ENODEparent($dragged))
+	markNeedsRefine(ENODEparent($(".CouldBeCollected")))
 	//$dragged.insertBefore($parentParent);
 	ENODEremove($dragged);
 	//$(".CouldBeCollected").remove()
 	ENODEremove($parentParent.find(".CouldBeCollected"))
-	$parentParent.addClass("Refine_c");
+	markNeedsRefine($parentParent);
 	PActx.$transform = extOp;
 	PActx.matchedTF = true
 	return PActx
@@ -615,7 +615,7 @@ function compose($toBeComp, firstVal, img) {
 		ENODEinsertBefore($composed, PActx.$operand[0]);
 		ENODEremove(PActx.$operand)
 		//ExtendAndInitializeTree($composed);
-		$parent.addClass('Refine_c');
+		markNeedsRefine($parent);
 		PActx.$transform = $parent;
 		PActx.visualization = img
 	}
@@ -670,7 +670,7 @@ function decompose($toBeDec, direction, img) {//"up" for factorize
 				}
 				//******Rimuovi il MINUS
 				ENODEinsertAfter($minusContent, $minus);
-				$minusContent.addClass("Refine_c");//if the content was a "times" it may by dissolved if the parent is also times
+				markNeedsRefine($minusContent);//if the content was a "times" it may by dissolved if the parent is also times
 				ENODEremove($minus);
 
 				//var $roleContainingFactors = $minusContent[0].ENODE_getRoles();
@@ -924,7 +924,7 @@ function removeRedundant($dragged, $target) {
 	PActx.replacedAlready = true;
 	if ($parent.attr("data-enode") == "and") {
 		ENODEremove($target);//if contained in an and simply remove the redundant term		
-		$parent.addClass("Refine_c");
+		markNeedsRefine($parent);
 	}
 	else {
 		const $clone = ENODEclone(prototypeSearch("ci", "bool"))

--- a/app/js/MAIN.js
+++ b/app/js/MAIN.js
@@ -297,31 +297,6 @@ function keyToCharacter(key) {
 	}
 }
 
-function refreshAndReplace(PActx) {
-	console.log("Applied property: " + PActx.msg)
-	//**** determina l'operazione più esterna su cui fare il refresh
-	let $toBeRefreshed
-
-	if (PActx.replacedAlready == true) {
-		// sostituzione già effettuano internamente alla proprietà
-		$toBeRefreshed = ENODEparent(PActx.$transform)
-	} else {
-		$toBeRefreshed = ENODEparent(PActx.$operand)
-		ENODEinsertBefore(PActx.$transform, PActx.$operand[0]);
-		ENODEremove(PActx.$operand)
-		//********select on exit
-		//$('*').removeClass('selected')
-		//$(PActx.$transform[0]).addClass('selected')	
-	}
-	//********Refresh***************
-
-	if ($toBeRefreshed !== undefined && $toBeRefreshed.length != 0) {
-
-		RefreshEmptyInfixBraketsGlued();
-	}
-	return PActx
-}
-
 function debugToggle() {
 	debugMode = !debugMode
 	//toggle debugMode
@@ -367,7 +342,7 @@ function PActxConclude(PActx) {
 		if (debugMode) { console.log('CONCLUDE') }
 		refreshAndReplace(PActx);
 		if (PActx.$transform) {
-			RepeatedRefine_c(PActx.$transform, 'c', '.Refine_c');//Apply "c" to every Node in the branch marked with '.Refine_c'
+			refineAfterProperty(PActx.$transform);//semplifica i nodi marcati con markNeedsRefine / Refine_c
 		}
 		RefreshEmptyInfixBraketsGlued($('body'), true);
 		ssnapshot.take();

--- a/app/js/PMTutilities.js
+++ b/app/js/PMTutilities.js
@@ -17,34 +17,6 @@ function newPActx() {
 	}
 }
 
-function RepeatedRefine_c($transform,key,selector){
-	//post-applicazione: riapplica la proprietà "key" (es. semplificazione "c")
-	//a ogni ENODE del ramo trasformato finché non ci sono più semplificazioni
-	let i=0
-	let semplificEffettuata = true; //la prima passata avviene come se la precedente avesse avuto successo.
-	let $transformParentRole = $transform.parent()//se il transform viene sostituito, continua a cercare a partire da l suo parent
-	while(semplificEffettuata == true && i<20){//limito il numero di tentativi per evitare loop infiniti
-		let $toBesemplified = $transformParentRole.find('[data-enode]')
-		if(selector){
-			$toBesemplified = $toBesemplified.filter(selector)
-		}
-		let j= ($toBesemplified.length - 1)
-    	semplificEffettuata = false;
-    	while( j>=0){//prova a semplificare il j-esimo ENODEo, parti dal fondo
-    		const refinementPActx = keyboardEvToFC($($toBesemplified[j]),key);
-			if(refinementPActx && refinementPActx.matchedTF){//semplificazione applicata con successo
-				refreshAndReplace(refinementPActx);
-				semplificEffettuata = true;
-				break
-    		}
-    		j--
-    	}
-    	i++
-    		
-	}
-	
-}
-
 function overwriteFromHeader($forAll) {
     //Dall’header di un forall sovrascrivi il suffisso "__" nel corpo del forall.
     //Attenzione!!, anche le marcature verranno sovrascritte nella sostituzione???
@@ -559,7 +531,7 @@ function PMcleanAndPost(PActx){
 	    	let postMarks = ENODESmarkUnmark($(this),undefined,"p");
 	    	if(postMarks.indexOf('c') != -1){// is "c" one of the post markings?
 				//transform post mark "--c" in cleanIfPossible to conform to markings used in internal functions
-	    		$(this).addClass('Refine_c');
+	    		markNeedsRefine(this);
 	    	}
 	    	//************remove all PM marks***********
     		$(this).removeClass('taken');

--- a/app/js/UserEvToFunctCall.js
+++ b/app/js/UserEvToFunctCall.js
@@ -131,4 +131,4 @@ function searchForProperty(field,value,returnedField){
 
 
 
-//RepeatedRefine_c è definita in PMTutilities.js (post-applicazione delle proprietà)
+//refineAfterProperty / markNeedsRefine: app/js/refine.js (post-applicazione delle proprietà)

--- a/app/js/refine.js
+++ b/app/js/refine.js
@@ -1,0 +1,85 @@
+// Post-applicazione proprietà (Property Application Mode): replace + refine.
+// Strato properties (software-modules.md). Comportamento invariato rispetto a
+// RepeatedRefine_c / refreshAndReplace precedentemente in PMTutilities.js e MAIN.js.
+//
+// Prossimi passi (non in questo file ancora):
+// - non dipendere da keyboardEvToFC('c') ma da un'API di semplificazione esplicita
+// - intensità di post (light / standard / full) su PActx
+
+/** Classe DOM: nodo candidato al refine dopo una proprietà */
+const REFINE_MARKER_CLASS = 'Refine_c';
+const REFINE_MARKER_SELECTOR = '.' + REFINE_MARKER_CLASS;
+/** Chiave in #events / keyboardEvToFC usata oggi per le semplificazioni automatiche */
+const REFINE_EVENT_KEY = 'c';
+
+/**
+ * Marca uno o più ENODE come da raffinare dopo PActxConclude.
+ * Unifica HW (.addClass Refine_c) e PM (post-mark "c").
+ */
+function markNeedsRefine($nodes) {
+	return $($nodes).addClass(REFINE_MARKER_CLASS);
+}
+
+/**
+ * Sostituisce l'operando con il transform (se non già fatto) e aggiorna infix/empty/brackets.
+ * Usata sia dal conclude esterno sia da ogni passo di refine.
+ */
+function refreshAndReplace(PActx) {
+	console.log("Applied property: " + PActx.msg)
+	let $toBeRefreshed
+
+	if (PActx.replacedAlready == true) {
+		$toBeRefreshed = ENODEparent(PActx.$transform)
+	} else {
+		$toBeRefreshed = ENODEparent(PActx.$operand)
+		ENODEinsertBefore(PActx.$transform, PActx.$operand[0]);
+		ENODEremove(PActx.$operand)
+	}
+
+	if ($toBeRefreshed !== undefined && $toBeRefreshed.length != 0) {
+		RefreshEmptyInfixBraketsGlued();
+	}
+	return PActx
+}
+
+/**
+ * Raffinamento iterativo sul ramo trasformato: prova la semplificazione (evento "c")
+ * su ogni nodo marcato finché non ci sono più match (max 20 passate).
+ * Non richiama PActxConclude (niente snapshot/celebrate intermedi).
+ *
+ * @param {jQuery} $transform - più grande elemento trasformato
+ * @param {{key?: string, selector?: string}} [options]
+ */
+function refineAfterProperty($transform, options) {
+	if (!$transform || !$transform.length) { return }
+	options = options || {}
+	const key = options.key != null ? options.key : REFINE_EVENT_KEY
+	const selector = options.selector != null ? options.selector : REFINE_MARKER_SELECTOR
+
+	let i = 0
+	let semplificEffettuata = true
+	let $transformParentRole = $transform.parent()
+	while (semplificEffettuata == true && i < 20) {
+		let $toBesemplified = $transformParentRole.find('[data-enode]')
+		if (selector) {
+			$toBesemplified = $toBesemplified.filter(selector)
+		}
+		let j = ($toBesemplified.length - 1)
+		semplificEffettuata = false
+		while (j >= 0) {
+			const refinementPActx = keyboardEvToFC($($toBesemplified[j]), key)
+			if (refinementPActx && refinementPActx.matchedTF) {
+				refreshAndReplace(refinementPActx)
+				semplificEffettuata = true
+				break
+			}
+			j--
+		}
+		i++
+	}
+}
+
+/** @deprecated usare refineAfterProperty — alias per compatibilità */
+function RepeatedRefine_c($transform, key, selector) {
+	return refineAfterProperty($transform, { key: key, selector: selector })
+}

--- a/project/specs/software-modules.md
+++ b/project/specs/software-modules.md
@@ -62,10 +62,11 @@ Punti d'attenzione nel nucleo:
 | `PatternMatchingTrasform.js` | ~250 | Lato "transform" del PM: lookup proprietà (`findPMPropByName`), clone e swap dei membri (`swapMembersClone`), tipizzazione parametri (`parameterType`, suffissi `_`/`__`/`___`), sostituzione nei `forAll` (`replaceInForall`), riformattazione se restano variabili libere (`reformatForallProp`) |
 | `HardWiredProperties.js` | ~1075 | Framework delle proprietà cablate: `newPActx`, registro DnD (`PropertyDnD`/`propertiesDnD`), validatori (`validFor*`), implementazioni (associate, distribute, collect, compose, decompose, replace/link, modus ponens, redundant, Hanoi, forThis, evaluateComparison), euristica parentesi (`ENODEneedsBracket`) |
 | `addedHardWiredProperties.js` | ~95 | Specializzazioni didattiche: `tabelline`, `composePlusOnly`, `decomposeTens`, helper `$toBeComposedWithSiblings` (chiamato da `compose` nel file principale: dipendenza inversa rispetto all'ordine di caricamento, funziona solo perché risolta a runtime) |
+| `refine.js` | ~85 | Post-applicazione proprietà: `markNeedsRefine`, `refreshAndReplace`, `refineAfterProperty` (ex `RepeatedRefine_c`). Marcatore DOM `Refine_c`; oggi richiama ancora `keyboardEvToFC(..., 'c')` |
 
 Concetti trasversali:
 
-- **`PActx`** (creato da `newPActx` in `HardWiredProperties.js`): contesto di applicazione di una proprietà. Campi principali: `matchedTF`, `msg`, `$pattern`, `$operand`, `$transform`, `$equation`, `$cloneProp`, `replacedAlready`, `visualization`. Le proprietà hard-wired di solito mutano il DOM da sole e impostano `replacedAlready=true`; le PM lasciano la sostituzione a `refreshAndReplace`.
+- **`PActx`** (creato da `newPActx` in `PMTutilities.js`): contesto di applicazione di una proprietà. Campi principali: `matchedTF`, `msg`, `$pattern`, `$operand`, `$transform`, `$equation`, `$cloneProp`, `replacedAlready`, `visualization`. Le proprietà hard-wired di solito mutano il DOM da sole e impostano `replacedAlready=true`; le PM lasciano la sostituzione a `refreshAndReplace` in `refine.js`.
 - **Dispatch per nome**: `TryOnePropertyByName(nome, ...)` cerca `$('[data-tag=nome]')`; se l'elemento è `ci` chiama `window[nome](...)` (il nome della funzione JS deve coincidere con `data-tag`), altrimenti avvia il PM. È l'accoppiamento più fragile del sistema.
 - **Marcature**: stringa `mark-link-post` in `title` (persistente, salvata in MML) o `mark` (volatile). `m` = vincoli di match (es. `s` selected, `d` dragged), `l` = etichette per i path di riordino, `p` = post-azioni (`c` = auto-refine, `n` = non riordinare).
 
@@ -75,9 +76,9 @@ Problemi noti: `evaluateComparison` usa `=` invece di `==` nei confronti su `ENO
 
 | File | righe | Responsabilità |
 |---|---|---|
-| `MAIN.js` | ~505 | Bootstrap e hub eventi: stato globale (`GLBsettings`, `debugMode`, `preloadPath`), listener document-level (click, dblclick, mousedown/up, touch, keydown), selezione (`selectionManager`), scorciatoie (undo/copy/paste/save/load/tab-tool), pipeline post-proprietà (`PActxConclude`, `refreshAndReplace`), celebrazione |
+| `MAIN.js` | ~505 | Bootstrap e hub eventi: stato globale (`GLBsettings`, `debugMode`, `preloadPath`), listener document-level (click, dblclick, mousedown/up, touch, keydown), selezione (`selectionManager`), scorciatoie (undo/copy/paste/save/load/tab-tool), orchestrazione post-proprietà (`PActxConclude` → `refine.js`), celebrazione |
 | `DnD.js` | ~355 | Motore drag & drop su SortableJS: al mousedown individua il nodo trascinabile e i target validi (riordino su untied, proprietà DnD, autoAdapt, copy), crea/riattiva pigramente i Sortable, gestisce il drop (`onAdd`: move/clone/proprietà), pulizia (`cleanupDnD`) |
-| `UserEvToFunctCall.js` | ~160 | Traduzione input → proprietà: mappa tasti sulle azioni in `#events` (`keyboardEvToFC`), filtro proprietà DnD abilitate (`getDnDpropEnabled`), refine iterativo (`RepeatedRefine_c`) |
+| `UserEvToFunctCall.js` | ~160 | Traduzione input → proprietà: mappa tasti sulle azioni in `#events` (`keyboardEvToFC`), filtro proprietà DnD abilitate (`getDnDpropEnabled`) |
 | `Undo.js` | ~80 | Undo a snapshot: stack `FILO` di cloni dell'albero radice, `ssnapshot.take/undo/copy/paste`. Nota: lo snapshot è preso *dopo* ogni azione |
 | `sound.js` | ~10 | 5 oggetti Audio precaricati (2 usati: `clickSound`, `victorySound`) |
 | `AldoUtilities.js` | ~290 | Cassetto di utilità eterogenee: pulizia classi, path/URL, confronto col risultato e celebrazione (`lookForResultAndCelebrate`, `compareWithResult`), parser semplice (`dummyParser`, `identifierToENODE`), antenato comune, grado dei monomi, comparatori per Sortable |
@@ -124,7 +125,7 @@ Globali **implicite** (assegnate senza `let`/`var`, inquinano `window`): `$clone
 
 1. **Responsabilità mal collocate**
    - UI dentro il nucleo espressioni: `prompt()`, icone, overlay, `ssnapshot.take()` in `ExpressionManager.js`; classi CSS e SVG dentro `calculateSpan.js`.
-   - Logica espressioni fuori dal nucleo: `ENODEneedsBracket` e `newPActx` in `HardWiredProperties.js`; `dummyParser`/`identifierToENODE` e `compareWithResult` in `AldoUtilities.js`; `GLBsettingsToInterface` (UI settings) in `preload.js`; `RepeatedRefine_c` in `UserEvToFunctCall.js`.
+   - Logica espressioni fuori dal nucleo: residui documentati altrove; post-applicazione proprietà ora in `refine.js`.
    - `AldoUtilities.js` è un cassetto senza coesione (utilità DOM + logica di gioco + parser + geometria d3 morta).
 2. **File e codice morto**: `utilities.js`, `InteractJStests.js`, `Ajax.js`, codice d3 hull, `swapElements`, `sorting`, `sortablesExcluded`, 3 suoni su 5, `revert`, `isEquationMember`, `clearTragets`, `PActxViewer`, `searchForMarked`, stub SVG, grandi blocchi commentati ovunque.
 3. **Bug latenti**: assegnamenti al posto di confronti (`inject`, `evaluateComparison`), funzioni che riferiscono simboli inesistenti (`ENODE_replaceWith`, `ENODEBesideGiven`), `$RolesAffectedByStartPropositionROLES` con variabili non definite in un ramo, `searchEventHandler` che logga una variabile inesistente.
@@ -191,7 +192,7 @@ Passi ordinati, ciascuno piccolo, testabile con la suite e2e + `smoke-expression
 ### Passo 5 — Ricollocamento delle funzioni fuori posto
 - `ENODEneedsBracket` → rendering (vicino a `refreshOneBracket`).
 - `newPActx` → un nuovo `properties/PActx.js` (o in cima a `PMTutilities.js`), così `HardWiredProperties` e `PMTutilities` dipendono da un punto comune.
-- `RepeatedRefine_c` → strato properties (è post-applicazione, non traduzione di eventi).
+- ~~`RepeatedRefine_c` → strato properties~~ fatto: `app/js/refine.js` (`refineAfterProperty`, `markNeedsRefine`).
 - Smontare `AldoUtilities.js`: `dummyParser`/`identifierToENODE` → core; `lookForResultAndCelebrate`/`compareWithResult` → nuovo modulo game/goal (interaction); utilità DOM generiche (`commonParent`, `removeClassByPrefix`, comparatori) → un `dom-utils.js`; il resto si elimina col passo 1.
 - Estrarre da `preload.js` la parte settings-UI (`GLBsettingsToInterface`, `populateDropdown`, listener `#settings`) in un `settings.js` (interaction); `preload.js` resta solo loader.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Cosa
Estrae la pipeline di refine dopo applicazione proprietà in `app/js/refine.js`, senza cambiare il comportamento.

## Dettagli
- Nuovo `refine.js`: `markNeedsRefine`, `refreshAndReplace`, `refineAfterProperty` (+ alias deprecato `RepeatedRefine_c`)
- `PActxConclude` chiama `refineAfterProperty`
- HW e `PMcleanAndPost` usano `markNeedsRefine` al posto di `.addClass('Refine_c')`
- Fix typo in `DnD.clearSortableTargets`: `refine_c` → `REFINE_MARKER_CLASS` (`Refine_c`)
- Caricamento in `index.html` nello strato properties; aggiornato `software-modules.md`

## Prossimi passi (fuori da questo PR)
- API di semplificazione esplicita al posto di `keyboardEvToFC(..., 'c')`
- Intensità post (light / standard / full) su `PActx`

## Test
Smoke + e2e hanoi in corso / da verificare in CI.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-103885ed-ea2e-4f88-8a6d-996ca7f42602"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-103885ed-ea2e-4f88-8a6d-996ca7f42602"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

